### PR TITLE
feat: add dark mode toggle with sun/moon icons

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,11 +19,15 @@ import Toast from './components/Toast.vue'
 import ImportModal from './components/ImportModal.vue'
 import ErrorBoundary from './components/ErrorBoundary.vue'
 import { useI18nStore } from './stores/i18n'
+import { useUIStore } from './stores/ui'
 import { getLocalizedPath } from './router/localizedRoutes'
 
 const router = useRouter()
 const route = useRoute()
 const i18n = useI18nStore()
+const ui = useUIStore()
+
+ui.initTheme()
 
 const currentLocale = () => (
   typeof i18n.locale === 'string'

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -15,6 +15,22 @@
       <button class="lang-toggle nav-lang-toggle" @click="i18n.toggleLocale()">
         {{ i18n.t('navbar.lang') }}
       </button>
+      <button class="theme-toggle nav-theme-toggle" @click="ui.toggleTheme()" :title="ui.theme === 'dark' ? 'Light mode' : 'Dark mode'">
+        <svg v-if="ui.theme === 'light'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+        </svg>
+        <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5"/>
+          <line x1="12" y1="1" x2="12" y2="3"/>
+          <line x1="12" y1="21" x2="12" y2="23"/>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+          <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+          <line x1="1" y1="12" x2="3" y2="12"/>
+          <line x1="21" y1="12" x2="23" y2="12"/>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+          <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        </svg>
+      </button>
     </div>
   </nav>
 </template>
@@ -22,6 +38,7 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
+import { useUIStore } from '../stores/ui'
 import { authService } from '../services/auth'
 import { useI18nStore } from '../stores/i18n'
 import { getLocalizedPath } from '../router/localizedRoutes'
@@ -29,6 +46,7 @@ import { logger } from '../utils/logger'
 
 const authStore = useAuthStore()
 const i18n = useI18nStore()
+const ui = useUIStore()
 const userResolved = ref(false)
 const currentLocale = computed(() => (
   typeof i18n.locale === 'string'
@@ -100,6 +118,27 @@ onMounted(async () => {
 .nav-lang-toggle:hover {
   color: var(--text-primary);
   border-color: var(--text-secondary);
+}
+
+.nav-theme-toggle {
+  font-family: var(--font-ui);
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  outline: none;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.nav-theme-toggle:hover {
+  color: var(--text-primary);
 }
 
 .nav-minimal a {

--- a/frontend/src/stores/ui.js
+++ b/frontend/src/stores/ui.js
@@ -5,10 +5,11 @@
  * - Modales
  * - Estados de carga
  * - Sidebar toggle
+ * - Theme (light/dark)
  */
 
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 export const useUIStore = defineStore('ui', () => {
   // State
@@ -17,6 +18,32 @@ export const useUIStore = defineStore('ui', () => {
   const isSidebarOpen = ref(true)
   const isProcessing = ref(false)
   const processingMessage = ref('')
+
+  // Theme
+  const theme = ref(localStorage.getItem('exogram-theme') || 'light')
+
+  const setTheme = (newTheme) => {
+    theme.value = newTheme
+    localStorage.setItem('exogram-theme', newTheme)
+    document.documentElement.setAttribute('data-theme', newTheme)
+  }
+
+  const toggleTheme = () => {
+    setTheme(theme.value === 'light' ? 'dark' : 'light')
+  }
+
+  // Initialize theme on load
+  const initTheme = () => {
+    document.documentElement.setAttribute('data-theme', theme.value)
+  }
+
+  // Watch for system preference changes if no saved preference
+  if (!localStorage.getItem('exogram-theme')) {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    if (prefersDark) {
+      setTheme('dark')
+    }
+  }
 
   // Toast management
   let toastCounter = 0
@@ -130,10 +157,16 @@ export const useUIStore = defineStore('ui', () => {
     processingMessage,
     setProcessing,
 
-    // Sidebar
-    isSidebarOpen,
-    toggleSidebar,
-    openSidebar,
-    closeSidebar,
-  }
+  // Sidebar
+  isSidebarOpen,
+  toggleSidebar,
+  openSidebar,
+  closeSidebar,
+
+  // Theme
+  theme,
+  setTheme,
+  toggleTheme,
+  initTheme,
+}
 })

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -475,3 +475,33 @@ section + section {
     padding: var(--space-xl);
   }
 }
+
+/* =============================================================================
+   Dark Mode
+   ============================================================================= */
+
+[data-theme="dark"] {
+  --bg-primary: #0F0F0F;
+  --bg-secondary: #1A1A1A;
+  --bg-tertiary: #222222;
+
+  --text-primary: #F0F0F0;
+  --text-secondary: #999999;
+  --text-tertiary: #666666;
+
+  --border-subtle: #2A2A2A;
+  --border-medium: #333333;
+
+  --accent-primary: #FFFFFF;
+  --accent-secondary: #CCCCCC;
+}
+
+[data-theme="dark"] input:focus,
+[data-theme="dark"] textarea:focus,
+[data-theme="dark"] select:focus {
+  background-color: var(--bg-secondary);
+}
+
+[data-theme="dark"] .btn-primary {
+  color: #000000;
+}

--- a/frontend/src/views/ForgotPassword.vue
+++ b/frontend/src/views/ForgotPassword.vue
@@ -4,6 +4,22 @@
       <div class="forgot-container">
         <header class="forgot-header">
           <router-link :to="localizedTo('login')" class="back-link">{{ i18n.t('forgot_password.back') }}</router-link>
+          <button class="theme-toggle" @click="ui.toggleTheme()" :title="ui.theme === 'dark' ? 'Light mode' : 'Dark mode'">
+            <svg v-if="ui.theme === 'light'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+            </svg>
+            <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="5"/>
+              <line x1="12" y1="1" x2="12" y2="3"/>
+              <line x1="12" y1="21" x2="12" y2="23"/>
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+              <line x1="1" y1="12" x2="3" y2="12"/>
+              <line x1="21" y1="12" x2="23" y2="12"/>
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+            </svg>
+          </button>
         </header>
 
         <form class="forgot-form" @submit.prevent="handleSubmit">
@@ -40,7 +56,7 @@ import { useUIStore } from '../stores/ui'
 import { useI18nStore } from '../stores/i18n'
 import { authService } from '../services/auth'
 import { getLocalizedPath } from '../router/localizedRoutes'
-const uiStore = useUIStore()
+const ui = useUIStore()
 const i18n = useI18nStore()
 const currentLocale = computed(() => (
   typeof i18n.locale === 'string'
@@ -188,5 +204,46 @@ const handleSubmit = async () => {
 .btn-enter:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.forgot-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-lg);
+}
+
+.back-link {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  text-decoration: none;
+  border-bottom: none;
+  letter-spacing: 0.03em;
+  transition: color var(--transition-fast);
+}
+
+.back-link:hover {
+  color: var(--text-primary);
+}
+
+.theme-toggle {
+  font-family: var(--font-ui);
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  outline: none;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.theme-toggle:hover {
+  color: var(--text-primary);
 }
 </style>

--- a/frontend/src/views/LandingPage.vue
+++ b/frontend/src/views/LandingPage.vue
@@ -2,11 +2,29 @@
   <div class="landing">
     <nav class="landing-nav">
       <span class="landing-brand">exogram</span>
-      <button class="lang-toggle" @click="i18n.toggleLocale()">
-        <Transition name="lang-swap" mode="out-in">
-          <span :key="i18n.locale">{{ i18n.t('landing.footer.lang') }}</span>
-        </Transition>
-      </button>
+      <div class="nav-right">
+        <button class="lang-toggle" @click="i18n.toggleLocale()">
+          <Transition name="lang-swap" mode="out-in">
+            <span :key="i18n.locale">{{ i18n.t('landing.footer.lang') }}</span>
+          </Transition>
+        </button>
+        <button class="theme-toggle" @click="ui.toggleTheme()" :title="ui.theme === 'dark' ? 'Light mode' : 'Dark mode'">
+          <svg v-if="ui.theme === 'light'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+          <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+          </svg>
+        </button>
+      </div>
     </nav>
 
     <main class="hero">
@@ -34,9 +52,11 @@
 import { computed } from 'vue'
 import PublicFooter from '../components/PublicFooter.vue'
 import { useI18nStore } from '../stores/i18n'
+import { useUIStore } from '../stores/ui'
 import { getLocalizedPath } from '../router/localizedRoutes'
 
 const i18n = useI18nStore()
+const ui = useUIStore()
 const currentLocale = computed(() => (
   typeof i18n.locale === 'string'
     ? i18n.locale
@@ -161,6 +181,33 @@ const localizedTo = (routeName, params = {}, query = {}, hash = '') => {
 .lang-toggle:hover {
   color: var(--text-primary);
   opacity: 0.9;
+}
+
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.theme-toggle {
+  font-family: var(--font-ui);
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  outline: none;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.theme-toggle:hover {
+  color: var(--text-primary);
 }
 
 .locale-fade-enter-active,

--- a/frontend/src/views/Library.vue
+++ b/frontend/src/views/Library.vue
@@ -942,16 +942,23 @@ const formatConnectionMeta = (highlight) => {
 }
 
 .favorite-btn:hover {
-  color: #b88a32;
-  border-color: rgba(184, 138, 50, 0.35);
-  background: rgba(184, 138, 50, 0.08);
+  color: #d4a842;
+  border-color: rgba(212, 168, 66, 0.35);
+  background: rgba(212, 168, 66, 0.08);
   transform: none;
 }
 
 .favorite-btn.is-favorite {
-  color: #b88a32;
-  border-color: rgba(184, 138, 50, 0.35);
-  background: rgba(184, 138, 50, 0.08);
+  color: #d4a842;
+  border-color: rgba(212, 168, 66, 0.35);
+  background: rgba(212, 168, 66, 0.08);
+}
+
+[data-theme="dark"] .favorite-btn:hover,
+[data-theme="dark"] .favorite-btn.is-favorite {
+  color: #d4a842;
+  border-color: rgba(212, 168, 66, 0.5);
+  background: rgba(212, 168, 66, 0.15);
 }
 
 .delete-btn {
@@ -973,10 +980,16 @@ const formatConnectionMeta = (highlight) => {
 }
 
 .delete-btn:hover:not(:disabled) {
-  color: #c53030;
-  border-color: rgba(197, 48, 48, 0.35);
-  background: rgba(197, 48, 48, 0.06);
+  color: #e06060;
+  border-color: rgba(224, 96, 96, 0.35);
+  background: rgba(224, 96, 96, 0.06);
   transform: none;
+}
+
+[data-theme="dark"] .delete-btn:hover:not(:disabled) {
+  color: #e06060;
+  border-color: rgba(224, 96, 96, 0.5);
+  background: rgba(224, 96, 96, 0.15);
 }
 
 .delete-btn:disabled {

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -4,6 +4,22 @@
       <div class="login-container">
         <header class="login-header">
           <router-link :to="localizedTo('landing')" class="back-link">{{ i18n.t('login.back') }}</router-link>
+          <button class="theme-toggle" @click="ui.toggleTheme()" :title="ui.theme === 'dark' ? 'Light mode' : 'Dark mode'">
+            <svg v-if="ui.theme === 'light'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+            </svg>
+            <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="5"/>
+              <line x1="12" y1="1" x2="12" y2="3"/>
+              <line x1="12" y1="21" x2="12" y2="23"/>
+              <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+              <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+              <line x1="1" y1="12" x2="3" y2="12"/>
+              <line x1="21" y1="12" x2="23" y2="12"/>
+              <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+              <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+            </svg>
+          </button>
         </header>
         
         <form @submit.prevent="handleLogin" class="login-form">
@@ -47,8 +63,8 @@
 import { ref, onMounted, computed } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import PublicFooter from '../components/PublicFooter.vue'
-import { useAuthStore } from '../stores/auth'
 import { useUIStore } from '../stores/ui'
+import { useAuthStore } from '../stores/auth'
 import { useI18nStore } from '../stores/i18n'
 import { logger } from '../utils/logger'
 import { authService } from '../services/auth'
@@ -57,7 +73,7 @@ import { getLocalizedPath } from '../router/localizedRoutes'
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
-const uiStore = useUIStore()
+const ui = useUIStore()
 const i18n = useI18nStore()
 const currentLocale = computed(() => (
   typeof i18n.locale === 'string'
@@ -241,5 +257,46 @@ const handleLogin = async () => {
 .btn-enter:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.login-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-lg);
+}
+
+.back-link {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary);
+  text-decoration: none;
+  border-bottom: none;
+  letter-spacing: 0.03em;
+  transition: color var(--transition-fast);
+}
+
+.back-link:hover {
+  color: var(--text-primary);
+}
+
+.theme-toggle {
+  font-family: var(--font-ui);
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  outline: none;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  line-height: 1.4;
+  display: flex;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.theme-toggle:hover {
+  color: var(--text-primary);
 }
 </style>

--- a/frontend/src/views/Philosophy.vue
+++ b/frontend/src/views/Philosophy.vue
@@ -6,6 +6,22 @@
         <button class="lang-toggle" @click="i18n.toggleLocale()">
           {{ i18n.t('landing.footer.lang') }}
         </button>
+        <button class="theme-toggle" @click="ui.toggleTheme()" :title="ui.theme === 'dark' ? 'Light mode' : 'Dark mode'">
+          <svg v-if="ui.theme === 'light'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+          </svg>
+          <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+          </svg>
+        </button>
         <router-link :to="localizedTo('login')" class="nav-link nav-link-enter">{{ i18n.t('nav.login') }}</router-link>
       </div>
     </nav>
@@ -95,6 +111,7 @@ import { computed, ref, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import PublicFooter from '../components/PublicFooter.vue'
 import { useI18nStore } from '../stores/i18n'
+import { useUIStore } from '../stores/ui'
 import { getLocalizedPath } from '../router/localizedRoutes'
 
 const DOG_CARTOON_SRC = '/images/newyorker-dog-cartoon.jpg'
@@ -102,6 +119,7 @@ const DOG_CARTOON_SRC = '/images/newyorker-dog-cartoon.jpg'
 const route = useRoute()
 const router = useRouter()
 const i18n = useI18nStore()
+const ui = useUIStore()
 const donationAlias = import.meta.env.VITE_DONATION_ALIAS || ''
 
 const currentLocale = computed(() => (


### PR DESCRIPTION
Hi @matzalazar, I had the idea to add dark mode to Exogram to avoid straining users' eyes and for those who love dark themes as much as I do. I hope you like this feature!

## Summary
- Added dark mode support using CSS custom properties and `data-theme` attribute
- Implemented theme toggle button (☀/☾) visible on all pages (Landing, Philosophy, Login, Forgot Password, Navbar)
- Theme preference persisted in `localStorage` with system preference detection
- Updated hardcoded colors in Library.vue for dark mode compatibility
- Fixed deprecated Vue Router `next()` callback syntax

## Changes
- `frontend/src/stores/ui.js`: Added theme state management (theme, toggleTheme, initTheme)
- `frontend/src/style.css`: Added `[data-theme="dark"]` with dark color variables
- `frontend/src/App.vue`: Initialize theme on app mount
- `frontend/src/views/LandingPage.vue`: Added theme toggle next to language selector
- `frontend/src/views/Philosophy.vue`: Added theme toggle next to language selector
- `frontend/src/components/Navbar.vue`: Added theme toggle for authenticated users
- `frontend/src/views/Library.vue`: Updated hardcoded colors (favorites, delete buttons) for dark mode
- `frontend/src/views/Login.vue`: Added theme toggle aligned with back link
- `frontend/src/views/ForgotPassword.vue`: Added theme toggle aligned with back link
- `frontend/src/router/index.js`: Migrated from deprecated `next()` to return value syntax

## Testing
- Tested theme toggle persistence across page reloads
- Verified system preference detection (`prefers-color-scheme`)
- Tested visibility on public pages (Landing, Philosophy, Login, Forgot Password) and authenticated pages (Navbar)